### PR TITLE
Fix/x forward

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mermer-official",
-  "version": "0.8.4",
+  "version": "0.8.4+1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/pages/admin/browse/index.tsx
+++ b/src/pages/admin/browse/index.tsx
@@ -182,7 +182,10 @@ export default function index({ allKmFromServer }: Props) {
 
 export const getServerSideProps: GetServerSideProps = (async (context) => {
   const host = context.req.headers.host
-  const protocol = context.req.headers['x-forwarded-proto'] || 'https'
+  const protocol = context.req.headers["x-forwarded-proto"]
+    ? "https"
+    : "http";
+
   if (!host) {
     return {
       notFound: true,

--- a/src/pages/admin/edit/[kmId].tsx
+++ b/src/pages/admin/edit/[kmId].tsx
@@ -186,7 +186,9 @@ export default function KmEdit({
 }
 export const getServerSideProps: GetServerSideProps = (async (context) => {
   const host = context.req.headers.host
-  const tmpProtocol = context.req.headers['x-forwarded-proto'] || 'https';
+  const tmpProtocol = context.req.headers["x-forwarded-proto"]
+    ? "https"
+    : "http";
   // Info (20240318 - Luphia) somtimes the protocol would be 'https,http' or 'http,https' so we need to split it
   const protocol = tmpProtocol.toString().split(',')[0];
   if (!host) {

--- a/src/pages/knowledge-management/[kmId].tsx
+++ b/src/pages/knowledge-management/[kmId].tsx
@@ -4,31 +4,31 @@ import Footer from '../../components/footer/footer';
 import Breadcrumb from '../../components/breadcrumb/breadcrumb';
 import Link from 'next/link';
 import KMArticle from '../../components/km_article/km_article';
-import {ImFacebook, ImTwitter, ImLinkedin2} from 'react-icons/im';
-import {FaRedditAlien} from 'react-icons/fa';
-import {RiArrowLeftSLine} from 'react-icons/ri';
-import {serverSideTranslations} from 'next-i18next/serverSideTranslations';
-import {IKnowledgeManagement} from '../../interfaces/km_article';
-import {ICrumbItem} from '../../interfaces/crumb_item';
-import {useTranslation} from 'next-i18next';
-import {TranslateFunction} from '../../interfaces/locale';
-import {MERURL} from '../../constants/url';
-import {DOMAIN, KM_DESCRIPTION_LIMIT, merMerKMViewerConfig} from '../../constants/config';
-import {GetServerSideProps} from 'next';
-import {truncateText} from '../../lib/common';
+import { ImFacebook, ImTwitter, ImLinkedin2 } from 'react-icons/im';
+import { FaRedditAlien } from 'react-icons/fa';
+import { RiArrowLeftSLine } from 'react-icons/ri';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { IKnowledgeManagement } from '../../interfaces/km_article';
+import { ICrumbItem } from '../../interfaces/crumb_item';
+import { useTranslation } from 'next-i18next';
+import { TranslateFunction } from '../../interfaces/locale';
+import { MERURL } from '../../constants/url';
+import { DOMAIN, KM_DESCRIPTION_LIMIT, merMerKMViewerConfig } from '../../constants/config';
+import { GetServerSideProps } from 'next';
+import { truncateText } from '../../lib/common';
 import useShareProcess from '../../lib/hooks/use_share_process';
-import {ISocialMedia, SocialMediaConstant, ShareSettings} from '../../constants/social_media';
-import {useEffect} from 'react';
-import {useRouter} from 'next/router';
-import {increaseViewAfterDelay} from '../../lib/increase_view_after_delay';
+import { ISocialMedia, SocialMediaConstant, ShareSettings } from '../../constants/social_media';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { increaseViewAfterDelay } from '../../lib/increase_view_after_delay';
 
 interface IPageProps {
   kmId: string;
   kmData: IKnowledgeManagement;
 }
 
-const KMDetailPage = ({kmId, kmData}: IPageProps) => {
-  const {t}: {t: TranslateFunction} = useTranslation('common');
+const KMDetailPage = ({ kmId, kmData }: IPageProps) => {
+  const { t }: { t: TranslateFunction } = useTranslation('common');
   const router = useRouter();
 
   if (!kmId || typeof kmId !== 'string') {
@@ -42,7 +42,7 @@ const KMDetailPage = ({kmId, kmData}: IPageProps) => {
   const shareUrl = `${DOMAIN}${MERURL.KM}/${kmData.id}`;
   const description = truncateText(kmData.description, KM_DESCRIPTION_LIMIT);
 
-  const {share} = useShareProcess({shareId: kmData.id});
+  const { share } = useShareProcess({ shareId: kmData.id });
 
   const crumbs: ICrumbItem[] = [
     {
@@ -78,7 +78,7 @@ const KMDetailPage = ({kmId, kmData}: IPageProps) => {
             key={key}
             className="text-2xl hover:text-lightBlue1"
             onClick={() => {
-              share({socialMedia: key as ISocialMedia, text: value.text});
+              share({ socialMedia: key as ISocialMedia, text: value.text });
             }}
           >
             {mediaIcon}
@@ -203,7 +203,9 @@ const KMDetailPage = ({kmId, kmData}: IPageProps) => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
   const host = context.req.headers.host;
-  const tmpProtocol = context.req.headers['x-forwarded-proto'] || 'https';
+  const tmpProtocol = context.req.headers["x-forwarded-proto"]
+    ? "https"
+    : "http";
   // Info (20240318 - Luphia) somtimes the protocol would be 'https,http' or 'http,https' so we need to split it
   const protocol = tmpProtocol.toString().split(',')[0];
   if (!host) {
@@ -212,7 +214,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     };
   }
 
-  const {locale, query} = context;
+  const { locale, query } = context;
   const kmId = query.kmId as string;
   // Fetch data from external API
   const response = await fetch(`${protocol}://${host}/api/kms/${kmId}?language=${locale}`);

--- a/src/pages/knowledge-management/author/[authorId].tsx
+++ b/src/pages/knowledge-management/author/[authorId].tsx
@@ -86,7 +86,9 @@ const AuthorPage = ({
 
 export const getServerSideProps: GetServerSideProps = (async (context) => {
   const host = context.req.headers.host
-  const tmpProtocol = context.req.headers['x-forwarded-proto'] || 'https';
+  const tmpProtocol = context.req.headers["x-forwarded-proto"]
+    ? "https"
+    : "http";
   // Info (20240318 - Luphia) somtimes the protocol would be 'https,http' or 'http,https' so we need to split it
   const protocol = tmpProtocol.toString().split(',')[0];
   if (!host) {

--- a/src/pages/knowledge-management/index.tsx
+++ b/src/pages/knowledge-management/index.tsx
@@ -3,24 +3,24 @@ import NavBar from '../../components/nav_bar/nav_bar';
 import Footer from '../../components/footer/footer';
 import Breadcrumb from '../../components/breadcrumb/breadcrumb';
 import KMPageBody from '../../components/km_page_body/km_page_body';
-import {useTranslation} from 'next-i18next';
-import {TranslateFunction} from '../../interfaces/locale';
-import {IKnowledgeManagement} from '../../interfaces/km_article';
-import {ICrumbItem} from '../../interfaces/crumb_item';
-import {serverSideTranslations} from 'next-i18next/serverSideTranslations';
-import {GetServerSideProps} from 'next';
-import {MERURL} from '../../constants/url';
+import { useTranslation } from 'next-i18next';
+import { TranslateFunction } from '../../interfaces/locale';
+import { IKnowledgeManagement } from '../../interfaces/km_article';
+import { ICrumbItem } from '../../interfaces/crumb_item';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { GetServerSideProps } from 'next';
+import { MERURL } from '../../constants/url';
 
 interface IPageProps {
   posts: IKnowledgeManagement[];
   categories: string[];
 }
 
-const KnowledgeManagementPage = ({posts, categories}: IPageProps) => {
-  const {t}: {t: TranslateFunction} = useTranslation('common');
+const KnowledgeManagementPage = ({ posts, categories }: IPageProps) => {
+  const { t }: { t: TranslateFunction } = useTranslation('common');
 
   const crumbs: ICrumbItem[] = [
-    {label: t('NAV_BAR.HOME'), path: MERURL.HOME},
+    { label: t('NAV_BAR.HOME'), path: MERURL.HOME },
     {
       label: t('NAV_BAR.KNOWLEDGE_MANAGEMENT'),
       path: MERURL.KM,
@@ -91,7 +91,9 @@ const KnowledgeManagementPage = ({posts, categories}: IPageProps) => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
   const host = context.req.headers.host;
-  const tmpProtocol = context.req.headers['x-forwarded-proto'] || 'https';
+  const tmpProtocol = context.req.headers["x-forwarded-proto"]
+    ? "https"
+    : "http";
   // Info (20240318 - Luphia) somtimes the protocol would be 'https,http' or 'http,https' so we need to split it
   const protocol = tmpProtocol.toString().split(',')[0];
   if (!host) {
@@ -99,7 +101,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
       notFound: true,
     };
   }
-  const {locale} = context;
+  const { locale } = context;
   // Fetch data from external API
   const response = await fetch(`${protocol}://${host}/api/kms?language=${locale}`);
   if (!response.ok) {


### PR DESCRIPTION
# Develop
- [x] #168

# Check List
- `src/pages/admin/browse/index.tsx`
- `src/pages/admin/edit/[kmId].tsx`
- `src/pages/knowledge-management/[kmId].tsx`
- `src/pages/knowledge-management/author/[authorId].tsx`
- `src/pages/knowledge-management/index.tsx`

參考以下兩篇：
- [https://stackoverflow.com/questions/65871390/how-to-determine-http-vs-https-in-nodejs-nextjs-api-handler](https://stackoverflow.com/questions/65871390/how-to-determine-http-vs-https-in-nodejs-nextjs-api-handler)
- [ Can't get protocol in server-side rendering #2469 ](https://github.com/vercel/next.js/issues/2469) 

將以下code做變換，這樣可以在provy時正常使用https, localhost也可以用http

> 舊
```
const tmpProtocol = context.req.headers['x-forwarded-proto'] || 'https';
```

> 新
```
  const tmpProtocol = context.req.headers["x-forwarded-proto"]
    ? "https"
    : "http";
```
